### PR TITLE
Bug fixes, new features, and performance optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # ingestor-rpc
-Ingestor that uses regular RPC to write data for ArchivalRPC
+Ingestor that uses regular RPC to write data to Hbase for ArchivalRPC
+
+## Features
+- Detect when approaching network tip and wait before requesting blocks that don't exist yet
+- Reverse order back-filling support
+- Optional argument to specify the block number to start from
+  - If not specified then ingestor will start from last populated block in Hbase
+- Hbase connection re-use
+- RPC endpoint HTTP/2 support with connection re-use
+- Number of threads to use for requesting and back-filling data
+
+## Usage
+```
+USAGE:
+    ingestor-rpc [FLAGS] [OPTIONS] --solana-rpc-url <URL>
+
+FLAGS:
+    -h, --help       Prints help information
+        --reverse    Backfill blocks in reverse order (requires --start-block)
+    -V, --version    Prints version information
+
+OPTIONS:
+        --hbase-address <ADDRESS>             The HBase address to connect to [default: http://localhost:8080]
+        --reader-threads <N>                  Number of reader threads [default: 1]
+        --rpc-poll-interval <MILLISECONDS>    Poll interval in milliseconds for Solana RPC [default: 100]
+        --solana-rpc-url <URL>                The Solana RPC URL to connect to
+        --start-block <SLOT>                  The slot number to start backfilling from
+```
+
+### Examples
+
+```
+RUST_LOG=debug ./ingestor-rpc --solana-rpc-url <RPC-ENDPOINT> --hbase-address <HBASE-THRIFT-ENDPOINT> --reader-threads 50
+```

--- a/src/hbase.rs
+++ b/src/hbase.rs
@@ -77,6 +77,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct HBaseConnection {
     address: String,
     timeout: Option<Duration>,
+    batch_size: usize,
 }
 
 impl HBaseConnection {
@@ -84,18 +85,19 @@ impl HBaseConnection {
         address: &str,
         _read_only: bool,
         timeout: Option<Duration>,
+        batch_size: usize,
     ) -> Self {
-        info!("Connecting to HBase at address {}", address.clone().to_string());
+        info!("Connecting to HBase at address {} with batch size {}", address.clone().to_string(), batch_size);
 
         Self {
             address: address.to_string(),
             timeout,
+            batch_size,
         }
     }
 
     pub fn client(&self) -> HBase {
         let mut channel = TTcpChannel::new();
-
         channel.open(self.address.clone()).unwrap();
 
         let (input_chan, output_chan) = channel.split().unwrap();
@@ -105,10 +107,7 @@ impl HBaseConnection {
 
         let client = HbaseSyncClient::new(input_prot, output_prot);
 
-        HBase {
-            client,
-            _timeout: self.timeout,
-        }
+        HBase::new(client, self.timeout, self.batch_size)
     }
 
     pub async fn put_bincode_cells_with_retry<T>(
@@ -156,9 +155,18 @@ type OutputProtocol = TBinaryOutputProtocol<OutputTransport>;
 pub struct HBase {
     client: HbaseSyncClient<InputProtocol, OutputProtocol>,
     _timeout: Option<Duration>,
+    batch_size: usize,
 }
 
 impl HBase {
+    pub fn new(client: HbaseSyncClient<InputProtocol, OutputProtocol>, timeout: Option<Duration>, batch_size: usize) -> Self {
+        Self {
+            client,
+            _timeout: timeout,
+            batch_size,
+        }
+    }
+
     /// Get `table` row keys in lexical order.
     ///
     /// If `start_at` is provided, the row key listing will start with key.
@@ -378,19 +386,26 @@ impl HBase {
     {
         let mut bytes_written = 0;
         let mut new_row_data = vec![];
-        for (row_key, data) in cells {
-            let serialized_data = bincode::serialize(&data).unwrap();
+        
+        // Process cells in batches
+        for chunk in cells.chunks(self.batch_size) {
+            let mut batch_data = Vec::with_capacity(chunk.len());
+            for (row_key, data) in chunk {
+                let serialized_data = bincode::serialize(&data).unwrap();
 
-            let data = if use_compression {
-                compress_best(&serialized_data)?
-            } else {
-                compress(CompressionMethod::NoCompression, &serialized_data)?
-            };
+                let data = if use_compression {
+                    compress_best(&serialized_data)?
+                } else {
+                    compress(CompressionMethod::NoCompression, &serialized_data)?
+                };
 
-            bytes_written += data.len();
-            new_row_data.push((row_key, vec![("bin".to_string(), data)]));
+                bytes_written += data.len();
+                batch_data.push((row_key, vec![("bin".to_string(), data)]));
+            }
+            new_row_data.extend(batch_data);
         }
 
+        // Send all data in a single RPC call
         self.put_row_data(table, "x", &new_row_data).await?;
         Ok(bytes_written)
     }
@@ -406,20 +421,27 @@ impl HBase {
     {
         let mut bytes_written = 0;
         let mut new_row_data = vec![];
-        for (row_key, data) in cells {
-            let mut buf = Vec::with_capacity(data.encoded_len());
-            data.encode(&mut buf).unwrap();
+        
+        // Process cells in batches
+        for chunk in cells.chunks(self.batch_size) {
+            let mut batch_data = Vec::with_capacity(chunk.len());
+            for (row_key, data) in chunk {
+                let mut buf = Vec::with_capacity(data.encoded_len());
+                data.encode(&mut buf).unwrap();
 
-            let data = if use_compression {
-                compress_best(&buf)?
-            } else {
-                compress(CompressionMethod::NoCompression, &buf)?
-            };
+                let data = if use_compression {
+                    compress_best(&buf)?
+                } else {
+                    compress(CompressionMethod::NoCompression, &buf)?
+                };
 
-            bytes_written += data.len();
-            new_row_data.push((row_key, vec![("proto".to_string(), data)]));
+                bytes_written += data.len();
+                batch_data.push((row_key, vec![("proto".to_string(), data)]));
+            }
+            new_row_data.extend(batch_data);
         }
 
+        // Send all data in a single RPC call
         self.put_row_data(table, "x", &new_row_data).await?;
         Ok(bytes_written)
     }
@@ -430,9 +452,9 @@ impl HBase {
         family_name: &str,
         row_data: &[(&RowKey, RowData)],
     ) -> Result<()> {
-        let mut mutation_batches = Vec::new();
+        let mut mutation_batches = Vec::with_capacity(row_data.len());
         for (row_key, cell_data) in row_data {
-            let mut mutations = Vec::new();
+            let mut mutations = Vec::with_capacity(cell_data.len());
             for (cell_name, cell_value) in cell_data {
                 let mut mutation_builder = MutationBuilder::default();
                 mutation_builder.column(family_name, cell_name);
@@ -443,7 +465,6 @@ impl HBase {
         }
 
         self.client.mutate_rows(table_name.as_bytes().to_vec(), mutation_batches, Default::default())?;
-
         Ok(())
     }
 

--- a/src/ledger_storage.rs
+++ b/src/ledger_storage.rs
@@ -35,7 +35,7 @@ use {
         warn
     },
     std::{
-        collections::{HashMap, HashSet},
+        collections::{HashSet, HashMap},
     },
     thiserror::Error,
     tokio::task::JoinError,
@@ -160,6 +160,8 @@ pub struct UploaderConfig {
     pub use_tx_compression: bool,
     pub use_tx_by_addr_compression: bool,
     pub use_tx_full_compression: bool,
+    pub batch_size: usize,
+    pub max_concurrent_connections: usize,
 }
 
 impl Default for UploaderConfig {
@@ -182,6 +184,8 @@ impl Default for UploaderConfig {
             use_tx_compression: true,
             use_tx_by_addr_compression: true,
             use_tx_full_compression: true,
+            batch_size: 5000,
+            max_concurrent_connections: 1,
         }
     }
 }
@@ -222,6 +226,7 @@ impl LedgerStorage {
             address.as_str(),
             read_only,
             timeout,
+            uploader_config.batch_size,
         )
             .await;
         Self {
@@ -289,12 +294,20 @@ impl LedgerStorage {
         slot: Slot,
         confirmed_block: VersionedConfirmedBlock,
     ) -> Result<()> {
-        let mut by_addr: HashMap<&Pubkey, Vec<TransactionByAddrInfo>> = HashMap::new();
-
         info!("Uploading block {:?} from slot {:?}", confirmed_block.blockhash, slot);
 
-        let mut tx_cells = vec![];
-        let mut full_tx_cells = vec![];
+        let connection = self.connection.clone();
+        let uploader_config = self.uploader_config.clone();
+        let block_time = confirmed_block.block_time;
+
+        // Prepare all data first
+        let mut tx_cells = Vec::with_capacity(confirmed_block.transactions.len());
+        let mut full_tx_cells = Vec::with_capacity(confirmed_block.transactions.len());
+        
+        // Group transactions by (address, slot) to prevent overwrites
+        let mut tx_by_addr_groups: HashMap<String, Vec<TransactionByAddrInfo>> = HashMap::new();
+
+        // Process all transactions in a single pass
         for (index, transaction_with_meta) in confirmed_block.transactions.iter().enumerate() {
             let VersionedTransactionWithStatusMeta { meta, transaction } = transaction_with_meta;
             let err = meta.status.clone().err();
@@ -306,204 +319,160 @@ impl LedgerStorage {
             let mut should_skip_tx_by_addr = false;
             let mut should_skip_full_tx = false;
 
-            if self.uploader_config.filter_voting_tx && is_voting_tx(transaction_with_meta) {
+            if uploader_config.filter_voting_tx && is_voting_tx(transaction_with_meta) {
                 should_skip_tx_by_addr = true;
                 should_skip_full_tx = true;
             }
 
-            let combined_keys = get_account_keys(&transaction_with_meta);
+            let combined_keys = get_account_keys(transaction_with_meta);
 
             if !should_skip_tx_by_addr {
                 for address in transaction_with_meta.account_keys().iter() {
-                    // Filter program accounts from tx-by-addr index
-                    if self.uploader_config.filter_program_accounts
+                    if uploader_config.filter_program_accounts
                         && is_program_account(address, transaction_with_meta, &combined_keys) {
                         continue;
                     }
 
-                    if should_skip_full_tx || !self.should_include_in_tx_full(address) {
+                    if should_skip_full_tx || !Self::should_include_in_tx_full(address, &uploader_config) {
                         should_skip_full_tx = true;
                     }
 
-                    if !is_sysvar_id(address) && self.should_include_in_tx_by_addr(address) {
-                        by_addr
-                            .entry(address)
-                            .or_default()
-                            .push(TransactionByAddrInfo {
+                    if !is_sysvar_id(address) && Self::should_include_in_tx_by_addr(address, &uploader_config) {
+                        let row_key = format!("{}/{}", address, slot_to_tx_by_addr_key(slot));
+                        
+                        // Group transactions by row key instead of creating separate entries
+                        tx_by_addr_groups.entry(row_key).or_insert_with(Vec::new).push(
+                            TransactionByAddrInfo {
                                 signature,
                                 err: err.clone(),
                                 index,
                                 memo: memo.clone(),
-                                block_time: confirmed_block.block_time,
-                            });
+                                block_time,
+                            }
+                        );
                     }
                 }
             }
 
-            if self.uploader_config.enable_full_tx && !should_skip_full_tx {
+            if uploader_config.enable_full_tx && !should_skip_full_tx {
                 should_skip_tx = true;
-
                 full_tx_cells.push((
                     signature.to_string(),
                     ConfirmedTransactionWithStatusMeta {
                         slot,
                         tx_with_meta: transaction_with_meta.clone().into(),
-                        block_time: confirmed_block.block_time,
+                        block_time,
                     }.into()
                 ));
             }
 
-            if !self.uploader_config.disable_tx && !should_skip_tx {
+            if !uploader_config.disable_tx && !should_skip_tx {
                 tx_cells.push((
                     signature.to_string(),
                     TransactionInfo {
                         slot,
                         index,
                         err,
-                        // memo,
                     },
                 ));
             }
         }
 
-        let tx_by_addr_cells: Vec<_> = by_addr
-            .into_iter()
-            .map(|(address, transaction_info_by_addr)| {
-                (
-                    format!("{}/{}", address, slot_to_tx_by_addr_key(slot)),
-                    tx_by_addr::TransactionByAddr {
-                        tx_by_addrs: transaction_info_by_addr
-                            .into_iter()
-                            .map(|by_addr| by_addr.into())
-                            .collect(),
-                    },
-                )
-            })
-            .collect();
+        // Convert grouped transactions to cells
+        let mut tx_by_addr_cells = Vec::with_capacity(tx_by_addr_groups.len());
+        for (row_key, transactions) in tx_by_addr_groups {
+            tx_by_addr_cells.push((
+                row_key,
+                tx_by_addr::TransactionByAddr {
+                    tx_by_addrs: transactions.into_iter().map(|t| t.into()).collect(),
+                },
+            ));
+        }
 
         let mut tasks = vec![];
+        let mut total_bytes_written = 0;
 
-        if !full_tx_cells.is_empty() && self.uploader_config.enable_full_tx {
-            let conn = self.connection.clone();
-            let full_tx_table_name = self.uploader_config.full_tx_table_name.clone();
-            let use_tx_full_compression = self.uploader_config.use_tx_full_compression.clone();
+        // Spawn tasks for each type of data
+        if !full_tx_cells.is_empty() && uploader_config.enable_full_tx {
+            let conn = connection.clone();
+            let full_tx_table_name = uploader_config.full_tx_table_name.clone();
+            let use_tx_full_compression = uploader_config.use_tx_full_compression;
             tasks.push(tokio::spawn(async move {
-                let result = conn.put_protobuf_cells_with_retry::<generated::ConfirmedTransactionWithStatusMeta>(
+                conn.put_protobuf_cells_with_retry::<generated::ConfirmedTransactionWithStatusMeta>(
                     full_tx_table_name.as_str(),
                     &full_tx_cells,
                     use_tx_full_compression
-                )
-                    .await;
-                result
+                ).await
             }));
         }
 
-        if !tx_cells.is_empty() && !self.uploader_config.disable_tx {
-            let conn = self.connection.clone();
-            let tx_table_name = self.uploader_config.tx_table_name.clone();
-            let use_tx_compression = self.uploader_config.use_tx_compression.clone();
-            debug!("spawning tx upload thread");
+        if !tx_cells.is_empty() && !uploader_config.disable_tx {
+            let conn = connection.clone();
+            let tx_table_name = uploader_config.tx_table_name.clone();
+            let use_tx_compression = uploader_config.use_tx_compression;
             tasks.push(tokio::spawn(async move {
-                debug!("calling put_bincode_cells_with_retry for tx");
                 conn.put_bincode_cells_with_retry::<TransactionInfo>(
                     tx_table_name.as_str(),
                     &tx_cells,
                     use_tx_compression
-                )
-                    .await
+                ).await
             }));
         }
 
-        if !tx_by_addr_cells.is_empty() && !self.uploader_config.disable_tx_by_addr {
-            let conn = self.connection.clone();
-            let tx_by_addr_table_name = self.uploader_config.tx_by_addr_table_name.clone();
-            let use_tx_by_addr_compression = self.uploader_config.use_tx_by_addr_compression.clone();
-            debug!("spawning tx-by-addr upload thread");
+        if !tx_by_addr_cells.is_empty() && !uploader_config.disable_tx_by_addr {
+            let conn = connection.clone();
+            let tx_by_addr_table_name = uploader_config.tx_by_addr_table_name.clone();
+            let use_tx_by_addr_compression = uploader_config.use_tx_by_addr_compression;
             tasks.push(tokio::spawn(async move {
-                debug!("calling put_protobuf_cells_with_retry tx-by-addr");
-                let result = conn.put_protobuf_cells_with_retry::<tx_by_addr::TransactionByAddr>(
+                conn.put_protobuf_cells_with_retry::<tx_by_addr::TransactionByAddr>(
                     tx_by_addr_table_name.as_str(),
                     &tx_by_addr_cells,
                     use_tx_by_addr_compression
-                )
-                    .await;
-                debug!("finished put_protobuf_cells_with_retry call for tx-by-addr");
-                result
+                ).await
             }));
         }
 
-        let mut _bytes_written = 0;
-        let mut maybe_first_err: Option<Error> = None;
-
-        debug!("waiting for all upload threads to finish...");
-
+        // Wait for all tasks to complete
         let results = futures::future::join_all(tasks).await;
-        debug!("got upload results");
         for result in results {
             match result {
                 Err(err) => {
-                    debug!("got error result {:?}", err);
-                    if maybe_first_err.is_none() {
-                        maybe_first_err = Some(Error::TokioJoinError(err));
-                    }
+                    error!("Task error: {:?}", err);
+                    return Err(Error::TokioJoinError(err));
                 }
                 Ok(Err(err)) => {
-                    debug!("got error result {:?}", err);
-                    if maybe_first_err.is_none() {
-                        maybe_first_err = Some(Error::HBaseError(err));
-                    }
+                    error!("HBase error: {:?}", err);
+                    return Err(Error::HBaseError(err));
                 }
                 Ok(Ok(bytes)) => {
-                    debug!("got success result");
-                    _bytes_written += bytes;
+                    total_bytes_written += bytes;
                 }
             }
         }
 
-        if let Some(err) = maybe_first_err {
-            debug!("returning upload error result {:?}", err);
-            return Err(err);
-        }
-
-        let _num_transactions = confirmed_block.transactions.len();
-
-        // Store the block itself last, after all other metadata about the block has been
-        // successfully stored.  This avoids partial uploaded blocks from becoming visible to
-        // `get_confirmed_block()` and `get_confirmed_blocks()`
-        let blocks_cells = [(
-            slot_to_blocks_key(slot, self.uploader_config.use_md5_row_key_salt),
-            confirmed_block.into()
-        )];
-
-        debug!("calling put_protobuf_cells_with_retry for blocks");
-
+        // Upload block data last
         if !self.uploader_config.disable_blocks {
-            _bytes_written += self
+            let blocks_cells = [(
+                slot_to_blocks_key(slot, self.uploader_config.use_md5_row_key_salt),
+                confirmed_block.into()
+            )];
+
+            total_bytes_written += self
                 .connection
                 .put_protobuf_cells_with_retry::<generated::ConfirmedBlock>(
                     self.uploader_config.blocks_table_name.as_str(),
                     &blocks_cells,
                     self.uploader_config.use_blocks_compression
                 )
-                .await
-                .map_err(|err| {
-                    error!("failed to upload block: {:?}", err);
-                    err
-                })?;
+                .await?;
         }
 
-        info!("Successfully uploaded block from slot {}", slot);
-        // datapoint_info!(
-        //     "storage-hbase-upload-block",
-        //     ("slot", slot, i64),
-        //     ("transactions", num_transactions, i64),
-        //     ("bytes", _bytes_written, i64),
-        // );
+        info!("Successfully uploaded block from slot {} ({} bytes)", slot, total_bytes_written);
         Ok(())
     }
 
-    fn should_include_in_tx_full(&self, address: &Pubkey) -> bool {
-        if let Some(ref filter) = self.uploader_config.tx_full_filter {
+    fn should_include_in_tx_full(address: &Pubkey, config: &UploaderConfig) -> bool {
+        if let Some(ref filter) = config.tx_full_filter {
             if filter.exclude {
                 // If exclude is true, exclude the address if it's in the set.
                 !filter.addrs.contains(address)
@@ -516,8 +485,8 @@ impl LedgerStorage {
         }
     }
 
-    fn should_include_in_tx_by_addr(&self, address: &Pubkey) -> bool {
-        if let Some(ref filter) = self.uploader_config.tx_by_addr_filter {
+    fn should_include_in_tx_by_addr(address: &Pubkey, config: &UploaderConfig) -> bool {
+        if let Some(ref filter) = config.tx_by_addr_filter {
             if filter.exclude {
                 // If exclude is true, exclude the address if it's in the set.
                 !filter.addrs.contains(address)

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,9 +32,9 @@ async fn create_consumer(
     rpc_url: String,
     hbase_address: String,
     reader_threads: usize,
-    writer_threads: usize,
-    channel_buffer_size: usize,
     rpc_poll_interval: u64,
+    start_block: Option<u64>,
+    reverse: bool,
 ) -> RpcConsumer {
     info!("Connecting to Solana RPC: {}", &rpc_url);
 
@@ -46,16 +46,15 @@ async fn create_consumer(
     };
     let storage = LedgerStorage::new_with_config(storage_config).await;
 
-    // let rpc_client = RpcClient::new(rpc_url);
     let rpc_client = Arc::new(RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed()));
 
     RpcConsumer::new(
         rpc_client,
         storage,
         reader_threads,
-        writer_threads,
-        channel_buffer_size,
         rpc_poll_interval,
+        start_block,
+        reverse,
     )
 }
 
@@ -65,9 +64,9 @@ async fn handle_message_receiving(
     rpc_url: String,
     hbase_address: String,
     reader_threads: usize,
-    writer_threads: usize,
-    channel_buffer_size: usize,
     rpc_poll_interval: u64,
+    start_block: Option<u64>,
+    reverse: bool,
 ) {
     debug!("Started consuming messages");
 
@@ -76,9 +75,9 @@ async fn handle_message_receiving(
         rpc_url,
         hbase_address,
         reader_threads,
-        writer_threads,
-        channel_buffer_size,
         rpc_poll_interval,
+        start_block,
+        reverse,
     ).await;
 
     let _ = rpc_consumer.consume().await;
@@ -148,6 +147,7 @@ fn process_arguments(matches: &ArgMatches) -> UploaderConfig {
         use_tx_compression,
         use_tx_by_addr_compression,
         use_tx_full_compression,
+        max_concurrent_connections: 1,
         ..Default::default()
     }
 }
@@ -199,27 +199,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("start_block")
+                .long("start-block")
+                .value_name("SLOT")
+                .help("The slot number to start backfilling from")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("reverse")
+                .long("reverse")
+                .help("Backfill blocks in reverse order (requires --start-block)")
+                .takes_value(false)
+                .requires("start_block"),
+        )
+        .arg(
             Arg::with_name("reader_threads")
                 .long("reader-threads")
                 .value_name("N")
                 .help("Number of reader threads")
                 .default_value("1")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("writer_threads")
-                .long("writer-threads")
-                .value_name("N")
-                .help("Number of writer threads")
-                .default_value("5")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("channel_buffer_size")
-                .long("channel-buffer-size")
-                .value_name("SIZE")
-                .help("Size of the channel buffer")
-                .default_value("10")
                 .takes_value(true),
         )
         .arg(
@@ -236,9 +234,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let solana_rpc_url = matches.value_of("solana_rpc_url").unwrap().to_string();
     let hbase_address = matches.value_of("hbase_address").unwrap().to_string();
     let reader_threads: usize = matches.value_of("reader_threads").unwrap().parse()?;
-    let writer_threads: usize = matches.value_of("writer_threads").unwrap().parse()?;
-    let channel_buffer_size: usize = matches.value_of("channel_buffer_size").unwrap().parse()?;
     let rpc_poll_interval: u64 = matches.value_of("rpc_poll_interval").unwrap().parse()?;
+    let start_block: Option<u64> = matches.value_of("start_block").map(|s| s.parse().unwrap());
+    let reverse = matches.is_present("reverse");
 
     let uploader_config = process_arguments(&matches);
 
@@ -251,9 +249,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         solana_rpc_url,
         hbase_address,
         reader_threads,
-        writer_threads,
-        channel_buffer_size,
         rpc_poll_interval,
+        start_block,
+        reverse,
     ).await;
 
     Ok(())

--- a/src/rpc_consumer.rs
+++ b/src/rpc_consumer.rs
@@ -3,10 +3,9 @@ use {
         ledger_storage::{LedgerStorage},
     },
     std::sync::Arc,
-    tokio::sync::{Mutex, mpsc},
-    tokio::time::{sleep, Duration, Instant},
+    tokio::time::{sleep, Duration},
     futures::future::join_all,
-    std::sync::atomic::{AtomicU64, Ordering},
+    std::sync::atomic::{AtomicU64, AtomicBool, Ordering},
     log::{debug, info, warn, error},
     solana_client::rpc_client::RpcClient,
     solana_binary_encoder::{
@@ -42,9 +41,9 @@ pub struct RpcConsumer {
     rpc_client: Arc<RpcClient>,
     storage: LedgerStorage,
     reader_threads: usize,
-    writer_threads: usize,
-    channel_buffer_size: usize,
     rpc_poll_interval: u64,
+    start_block: Option<u64>,
+    reverse: bool,
 }
 
 impl RpcConsumer {
@@ -52,17 +51,17 @@ impl RpcConsumer {
         rpc_client: Arc<RpcClient>,
         storage: LedgerStorage,
         reader_threads: usize,
-        writer_threads: usize,
-        channel_buffer_size: usize,
         rpc_poll_interval: u64,
+        start_block: Option<u64>,
+        reverse: bool,
     ) -> Self {
         RpcConsumer {
             rpc_client,
             storage,
             reader_threads,
-            writer_threads,
-            channel_buffer_size,
             rpc_poll_interval,
+            start_block,
+            reverse,
         }
     }
 
@@ -72,108 +71,285 @@ impl RpcConsumer {
         let first_slot = self.rpc_client.get_first_available_block()?;
         let _latest_slot = self.rpc_client.get_slot()?;
 
-        let latest_stored_slot = match self.storage.get_latest_stored_slot(first_slot).await {
-            Ok(slot) => slot,
-            Err(e) => return Err(Box::new(e)),
+        let latest_stored_slot = if let Some(start_block) = self.start_block {
+            if self.reverse {
+                info!("Starting reverse backfill from block {}", start_block);
+                start_block + 1  // We'll decrement from here
+            } else {
+                info!("Starting forward backfill from block {}", start_block);
+                start_block - 1  // We'll increment from here
+            }
+        } else {
+            match self.storage.get_latest_stored_slot(first_slot).await {
+                Ok(slot) => slot,
+                Err(e) => return Err(Box::new(e)),
+            }
         };
 
         // Check for gaps between the latest stored slot and the first available slot
-        if latest_stored_slot < first_slot - 1 {
+        if !self.reverse && latest_stored_slot < first_slot - 1 {
             println!(
                 "Warning: There is a gap between the latest written slot in HBase ({}) and the earliest available block in the validator ({}).",
                 latest_stored_slot, first_slot
             );
         }
 
-        let (tx, rx) = mpsc::channel(self.channel_buffer_size);
-        let rx = Arc::new(Mutex::new(rx));
-        let current_slot = Arc::new(AtomicU64::new(latest_stored_slot + 1));
-        let mut message_counter = 0;
-        let report_interval = 10;
-        let mut batch_time = Instant::now();
+        // For reverse mode, use different logic
+        if self.reverse {
+            let current_slot = Arc::new(AtomicU64::new(latest_stored_slot));
+            
+            // Spawn worker tasks for reverse backfilling
+            let worker_handles: Vec<_> = (0..self.reader_threads).map(|worker_id| {
+                let rpc_client = Arc::clone(&self.rpc_client);
+                let storage = self.storage.clone();
+                let current_slot = Arc::clone(&current_slot);
+                let rpc_poll_interval = self.rpc_poll_interval;
+                let first_slot = first_slot;
+                
+                tokio::spawn(async move {
+                    loop {
+                        let slot = current_slot.fetch_sub(1, Ordering::SeqCst);
+                        
+                        // Stop if we've gone below the first available slot
+                        if slot < first_slot || slot == 0 {
+                            info!("Worker {} reached first available slot {}, stopping", worker_id, first_slot);
+                            break;
+                        }
 
-        // Spawn fetcher tasks
-        let fetcher_handles: Vec<_> = (0..self.reader_threads).map(|_| {
-            let rpc_client = Arc::clone(&self.rpc_client);
-            let tx = tx.clone();
-            let current_slot = Arc::clone(&current_slot);
-            let rpc_poll_interval = self.rpc_poll_interval;
-            tokio::spawn(async move {
-                loop {
-                    let slot = current_slot.fetch_add(1, Ordering::SeqCst);
+                        match get_raw_block(&rpc_client, slot) {
+                            Ok(block_data) => {
+                                if block_data.is_null() {
+                                    warn!("Block data from slot {} is null. Skipping.", slot);
+                                    continue;
+                                }
 
-                    match get_raw_block(&rpc_client, slot) {
-                        Ok(block_data) => {
-                            if tx.send((slot, block_data)).await.is_err() {
-                                break;
+                                info!("Worker {} received block from slot {} (reverse)", worker_id, slot);
+
+                                let block: EncodedConfirmedBlock = match serde_json::from_value(block_data) {
+                                    Ok(block) => block,
+                                    Err(e) => {
+                                        warn!("Failed to parse block data from slot {}: {:?}", slot, e);
+                                        continue;
+                                    }
+                                };
+
+                                let options = BlockEncodingOptions {
+                                    transaction_details: TransactionDetails::Full,
+                                    show_rewards: true,
+                                    max_supported_transaction_version: Some(0),
+                                };
+
+                                let conversion_result = convert_block(block, UiTransactionEncoding::Json, options)
+                                    .map_err(|e| e.to_string());
+
+                                match conversion_result {
+                                    Ok(versioned_block) => {
+                                        match storage.upload_confirmed_block(slot, versioned_block).await {
+                                            Ok(_) => {
+                                                info!("Worker {} finished processing block from slot {} (reverse)", worker_id, slot);
+                                            },
+                                            Err(e) => warn!("Failed to process block from slot {}: {:?}", slot, e),
+                                        }
+                                    },
+                                    Err(e) => {
+                                        warn!("Failed to convert block from slot {}: {:?}", slot, e);
+                                    }
+                                }
+                            },
+                            Err(e) => {
+                                let error_msg = e.to_string();
+                                if error_msg.contains("Block not available") || error_msg.contains("-32004") {
+                                    debug!("Block not available for slot {} (reverse)", slot);
+                                } else {
+                                    error!("Error fetching block data from slot {}: {:?}", slot, e);
+                                }
                             }
-                        },
-                        Err(e) => {
-                            error!("Error fetching block data from slot {}: {:?}", slot, e);
                         }
+
+                        sleep(Duration::from_millis(rpc_poll_interval)).await;
                     }
+                })
+            }).collect();
 
-                    sleep(Duration::from_millis(rpc_poll_interval)).await;
-                }
-            })
-        }).collect();
+            // Wait for all workers to finish
+            join_all(worker_handles).await;
+            
+        } else {
+            // Original forward implementation
+            let current_slot = Arc::new(AtomicU64::new(latest_stored_slot + 1));
+            let is_caught_up = Arc::new(AtomicBool::new(false));
+            let latest_network_slot = Arc::new(AtomicU64::new(_latest_slot));
 
-        // Spawn writer tasks
-        let writer_handles: Vec<_> = (0..self.writer_threads).map(|_| {
-            let storage = self.storage.clone();
-            let rx = Arc::clone(&rx);
-            tokio::spawn(async move {
-                while let Some((slot, block_data)) = rx.lock().await.recv().await {
-                    info!("Received block from slot {}", slot);
-
-                    if block_data.is_null() {
-                        warn!("Block data from slot {} is null. Skipping.", slot);
-                        continue;
-                    }
-
-                    let block: EncodedConfirmedBlock = match serde_json::from_value(block_data) {
-                        Ok(block) => block,
-                        Err(e) => {
-                            warn!("Failed to parse block data from slot {}: {:?}", slot, e);
-                            continue;
-                        }
-                    };
-
-                    let options = BlockEncodingOptions {
-                        transaction_details: TransactionDetails::Full,
-                        show_rewards: true,
-                        max_supported_transaction_version: Some(0),
-                    };
-
-                    let conversion_result = convert_block(block, UiTransactionEncoding::Json, options)
-                        .map_err(|e| e.to_string());
-
-                    match conversion_result {
-                        Ok(versioned_block) => {
-                            match storage.upload_confirmed_block(slot, versioned_block).await {
-                                Ok(_) => info!("Finished processing block from slot {}", slot),
-                                Err(e) => warn!("Failed to process block from slot {}: {:?}", slot, e),
+            // Spawn a task to periodically update the latest network slot
+            let network_slot_updater = {
+                let rpc_client = Arc::clone(&self.rpc_client);
+                let latest_network_slot = Arc::clone(&latest_network_slot);
+                let is_caught_up = Arc::clone(&is_caught_up);
+                let current_slot = Arc::clone(&current_slot);
+                
+                tokio::spawn(async move {
+                    loop {
+                        sleep(Duration::from_secs(2)).await;
+                        
+                        match rpc_client.get_slot() {
+                            Ok(latest) => {
+                                latest_network_slot.store(latest, Ordering::SeqCst);
+                                
+                                // Update caught up status
+                                let current = current_slot.load(Ordering::SeqCst);
+                                let was_caught_up = is_caught_up.load(Ordering::SeqCst);
+                                let now_caught_up = current >= latest.saturating_sub(32); // Within 32 slots is "caught up"
+                                
+                                if !was_caught_up && now_caught_up {
+                                    info!("Caught up to network tip at slot {}", latest);
+                                } else if was_caught_up && !now_caught_up {
+                                    info!("Fell behind network tip, catching up...");
+                                }
+                                
+                                is_caught_up.store(now_caught_up, Ordering::SeqCst);
                             }
-                        },
-                        Err(e) => {
-                            warn!("Failed to convert block from slot {}: {:?}", slot, e);
+                            Err(e) => {
+                                error!("Failed to update latest network slot: {:?}", e);
+                            }
                         }
                     }
+                })
+            };
 
-                    message_counter += 1;
-                    if message_counter % report_interval == 0 {
-                        let batch_duration: Duration = batch_time.elapsed();
-                        info!("Processed {} blocks, total time taken: {:?}", report_interval, batch_duration);
-                        batch_time = Instant::now();
+            // Spawn worker tasks that both fetch and process blocks
+            let reader_threads = self.reader_threads;
+            let worker_handles: Vec<_> = (0..reader_threads).map(|worker_id| {
+                let rpc_client = Arc::clone(&self.rpc_client);
+                let storage = self.storage.clone();
+                let current_slot = Arc::clone(&current_slot);
+                let is_caught_up = Arc::clone(&is_caught_up);
+                let latest_network_slot = Arc::clone(&latest_network_slot);
+                let rpc_poll_interval = self.rpc_poll_interval;
+                
+                tokio::spawn(async move {
+                    let mut consecutive_not_available = 0;
+                    let mut last_slot_check = 0u64;
+                    
+                    loop {
+                        let slot = current_slot.fetch_add(1, Ordering::SeqCst);
+                        
+                        // If we're caught up, check if this slot is beyond the network tip
+                        if is_caught_up.load(Ordering::SeqCst) {
+                            let latest = latest_network_slot.load(Ordering::SeqCst);
+                            if slot > latest + 1 {
+                                // We're ahead of the network, back off
+                                current_slot.fetch_sub(1, Ordering::SeqCst);
+                                debug!("Worker {} waiting at network tip (slot {})", worker_id, latest);
+                                sleep(Duration::from_millis(400)).await; // ~1 slot time
+                                continue;
+                            }
+                        }
+
+                        match get_raw_block(&rpc_client, slot) {
+                            Ok(block_data) => {
+                                consecutive_not_available = 0;
+                                
+                                if block_data.is_null() {
+                                    warn!("Block data from slot {} is null. Skipping.", slot);
+                                    continue;
+                                }
+
+                                info!("Worker {} received block from slot {}", worker_id, slot);
+
+                                let block: EncodedConfirmedBlock = match serde_json::from_value(block_data) {
+                                    Ok(block) => block,
+                                    Err(e) => {
+                                        warn!("Failed to parse block data from slot {}: {:?}", slot, e);
+                                        continue;
+                                    }
+                                };
+
+                                let options = BlockEncodingOptions {
+                                    transaction_details: TransactionDetails::Full,
+                                    show_rewards: true,
+                                    max_supported_transaction_version: Some(0),
+                                };
+
+                                let conversion_result = convert_block(block, UiTransactionEncoding::Json, options)
+                                    .map_err(|e| e.to_string());
+
+                                match conversion_result {
+                                    Ok(versioned_block) => {
+                                        match storage.upload_confirmed_block(slot, versioned_block).await {
+                                            Ok(_) => {
+                                                info!("Worker {} finished processing block from slot {}", worker_id, slot);
+                                            },
+                                            Err(e) => warn!("Failed to process block from slot {}: {:?}", slot, e),
+                                        }
+                                    },
+                                    Err(e) => {
+                                        warn!("Failed to convert block from slot {}: {:?}", slot, e);
+                                    }
+                                }
+                                
+                                // Use shorter poll interval when catching up
+                                if !is_caught_up.load(Ordering::SeqCst) {
+                                    sleep(Duration::from_millis(rpc_poll_interval)).await;
+                                }
+                            },
+                            Err(e) => {
+                                let error_msg = e.to_string();
+                                if error_msg.contains("Block not available") || error_msg.contains("-32004") {
+                                    consecutive_not_available += 1;
+                                    
+                                    // Only check actual network slot after multiple failures and not too frequently
+                                    if consecutive_not_available > 3 && slot.saturating_sub(last_slot_check) > 100 {
+                                        match rpc_client.get_slot() {
+                                            Ok(actual_latest) => {
+                                                last_slot_check = slot;
+                                                latest_network_slot.store(actual_latest, Ordering::SeqCst);
+                                                
+                                                if slot > actual_latest + 5 {
+                                                    // We're genuinely ahead, reset to a safe position
+                                                    let reset_to = actual_latest.saturating_sub(reader_threads as u64 * 2);
+                                                    current_slot.store(reset_to, Ordering::SeqCst);
+                                                    info!("Worker {} checked network: latest slot is {}, resetting to {}", 
+                                                          worker_id, actual_latest, reset_to);
+                                                    consecutive_not_available = 0;
+                                                    sleep(Duration::from_millis(1000)).await;
+                                                    continue;
+                                                } else {
+                                                    // We're close to the tip, just wait
+                                                    debug!("Worker {} at slot {} near tip ({}), waiting...", 
+                                                           worker_id, slot, actual_latest);
+                                                    current_slot.fetch_sub(1, Ordering::SeqCst);
+                                                    sleep(Duration::from_millis(400)).await;
+                                                    continue;
+                                                }
+                                            }
+                                            Err(rpc_err) => {
+                                                error!("Worker {} failed to get latest slot: {:?}", worker_id, rpc_err);
+                                            }
+                                        }
+                                    }
+                                    
+                                    // Don't spam logs when caught up
+                                    if !is_caught_up.load(Ordering::SeqCst) && consecutive_not_available < 3 {
+                                        debug!("Block not available for slot {}", slot);
+                                    }
+                                    
+                                    // Back off a bit and retry
+                                    current_slot.fetch_sub(1, Ordering::SeqCst);
+                                    sleep(Duration::from_millis(200)).await;
+                                } else {
+                                    error!("Error fetching block data from slot {}: {:?}", slot, e);
+                                    sleep(Duration::from_millis(500)).await;
+                                }
+                            }
+                        }
                     }
-                }
-            })
-        }).collect();
+                })
+            }).collect();
 
-        // Wait for fetchers and writers to finish
-        join_all(fetcher_handles).await;
-        drop(tx);
-        join_all(writer_handles).await;
+            // Wait for all workers to finish
+            join_all(worker_handles).await;
+            network_slot_updater.abort();
+        }
 
         Ok(())
     }


### PR DESCRIPTION
# Bug Fixes
- Fixed a bug where ingestor was overwriting signatures for an account that were processed in the same block. This caused missing data for the `getSignaturesForAddress` RPC method when there were two signatures processed in the same block for a specific address.
- Detect when approaching network tip and wait before requesting blocks that don't exist yet

# New Features
- Reverse order back-filling support
- Optional argument to specify the block number to start from

# Performance Optimizations
- Hbase connection re-use
- RPC endpoint HTTP/2 support with connection re-use

# Removals
- `--writer-threads`
- `--channel-buffer-size`

Using `--reader-threads 120`, I am able to achieve an ingestion speed of around 45 blocks per second (averaged taken over 48 hours of running). I suspect the bottleneck now is the RPC endpoint as the ingestion speed is directly correlated with the average response time of the `getBlock` RPC method requests. I encountered performance regressions when trying to use more than 120 threads. But I suspect this is due to sub-optimal Hbase configurations on my side not handling that many write tasks in parallel well.

I apologize in advance for the large commit. This is something that I have been working on over the past couple months and I ended up removing a lot of features that I added and ended up not keeping. So there might be some old references that are not used anymore.